### PR TITLE
Fix bug in dart-sass.js

### DIFF
--- a/tasks/dart-sass.js
+++ b/tasks/dart-sass.js
@@ -38,7 +38,7 @@ module.exports = async function (grunt) {
         const { src: [src], dest } = file;
 
         // Validate the source.
-        if( !src || _.startsWith(path.basename(src), '_') ) return;
+        if( !src || _.startsWith(path.basename(src), '_') ) continue; // this was returning upon the first instance of an invalid source file, therefore stopping processing
 
         // Render the Sass file.
         const result = sass.renderSync(_.merge({}, options, {


### PR DESCRIPTION
The validation of files within the for-loop was returning instead of continuing after hitting an invalid file.